### PR TITLE
Updates to experiments and modules

### DIFF
--- a/bom/setup-linux.sh
+++ b/bom/setup-linux.sh
@@ -38,7 +38,7 @@ curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.16
 chmod +x aws-iam-authenticator
 sudo mv aws-iam-authenticator /usr/local/bin
 
-OCTANT_VERSION=0.15.0
+OCTANT_VERSION=0.16.0
 wget https://github.com/vmware-tanzu/octant/releases/download/v${OCTANT_VERSION}/octant_${OCTANT_VERSION}_Linux-64bit.deb
 sudo dpkg -i octant_${OCTANT_VERSION}_Linux-64bit.deb
 

--- a/experiments/amazon/iam/iam.tf
+++ b/experiments/amazon/iam/iam.tf
@@ -104,7 +104,7 @@ output "this_iam_user_unique_id" {
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.9.0"
   region  = var.region
 }
 

--- a/experiments/k8s/eduk8s/cert.template
+++ b/experiments/k8s/eduk8s/cert.template
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: eduk8s-cert

--- a/modules/acme/aws/main.tf
+++ b/modules/acme/aws/main.tf
@@ -1,7 +1,7 @@
 provider "acme" {
   server_url = "https://acme-v02.api.letsencrypt.org/directory"
 
-  version = "~> 1.4.0"
+  version = "~> 1.5.0"
 }
 
 resource "tls_private_key" "private_key" {

--- a/modules/acme/azure/main.tf
+++ b/modules/acme/azure/main.tf
@@ -1,7 +1,7 @@
 provider "acme" {
   server_url = "https://acme-v02.api.letsencrypt.org/directory"
 
-  version = "~> 1.4.0"
+  version = "~> 1.5.0"
 }
 
 resource "tls_private_key" "private_key" {

--- a/modules/acme/gcp/main.tf
+++ b/modules/acme/gcp/main.tf
@@ -1,7 +1,7 @@
 provider "acme" {
   server_url = "https://acme-v02.api.letsencrypt.org/directory"
 
-  version = "~> 1.4.0"
+  version = "~> 1.5.0"
 }
 
 resource "tls_private_key" "private_key" {

--- a/modules/argo-cd/providers.tf
+++ b/modules/argo-cd/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/blobstore/azure/providers.tf
+++ b/modules/blobstore/azure/providers.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = ">=2.0.0"
+  version = ">=2.30.0"
   client_id = var.az_client_id
   subscription_id = var.az_subscription_id
   tenant_id = var.az_tenant_id

--- a/modules/certmanager/amazon/main.tf
+++ b/modules/certmanager/amazon/main.tf
@@ -52,7 +52,7 @@ resource "helm_release" "certmanager" {
   namespace  = kubernetes_namespace.certmanager.metadata[0].name
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.0.1"
+  version    = "v1.0.2"
 
   set {
     name = "installCRDs"

--- a/modules/certmanager/amazon/providers.tf
+++ b/modules/certmanager/amazon/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/certmanager/amazon/templates/cluster-issuer.yml
+++ b/modules/certmanager/amazon/templates/cluster-issuer.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/modules/certmanager/azure/main.tf
+++ b/modules/certmanager/azure/main.tf
@@ -53,7 +53,7 @@ resource "helm_release" "certmanager" {
   namespace  = kubernetes_namespace.certmanager.metadata[0].name
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.0.1"
+  version    = "v1.0.2"
 
   set {
     name = "installCRDs"

--- a/modules/certmanager/azure/providers.tf
+++ b/modules/certmanager/azure/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/certmanager/azure/templates/cluster-issuer.yml
+++ b/modules/certmanager/azure/templates/cluster-issuer.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -12,7 +12,7 @@ spec:
     solvers:
     # @see https://cert-manager.io/docs/configuration/acme/dns01/azuredns/
     - dns01:
-        azuredns:
+        azureDNS:
           clientID: ${clientId}
           clientSecretSecretRef:
             # The following is the secret we created in Kubernetes. Issuer will use this to present challenge to Azure DNS.

--- a/modules/certmanager/gcp/main.tf
+++ b/modules/certmanager/gcp/main.tf
@@ -50,7 +50,7 @@ resource "helm_release" "certmanager" {
   namespace  = kubernetes_namespace.certmanager.metadata[0].name
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "v1.0.1"
+  version    = "v1.0.2"
 
   set {
     name = "installCRDs"

--- a/modules/certmanager/gcp/providers.tf
+++ b/modules/certmanager/gcp/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/certmanager/gcp/templates/cluster-issuer.yml
+++ b/modules/certmanager/gcp/templates/cluster-issuer.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
@@ -14,7 +14,7 @@ spec:
       name: letsencrypt-prod
     solvers:
     - dns01:
-        clouddns:
+        cloudDNS:
           # Set this to your GCP project-id
           project: ${project}
           # Set this to the secret that we publish our service account key

--- a/modules/cf4k8s/providers.tf
+++ b/modules/cf4k8s/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/cf4k8s/templates/cert.yml
+++ b/modules/cf4k8s/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cf4k8s-cert

--- a/modules/concourse/providers.tf
+++ b/modules/concourse/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/concourse/templates/cert.yml
+++ b/modules/concourse/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: concourse-cert

--- a/modules/dns/amazon/providers.tf
+++ b/modules/dns/amazon/providers.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.9.0"
   region  = var.region
 }
 

--- a/modules/elasticsearch/providers.tf
+++ b/modules/elasticsearch/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/external-dns/amazon/providers.tf
+++ b/modules/external-dns/amazon/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/external-dns/azure/providers.tf
+++ b/modules/external-dns/azure/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/external-dns/gcp/main.tf
+++ b/modules/external-dns/gcp/main.tf
@@ -23,7 +23,7 @@ resource "helm_release" "external_dns" {
   namespace  = kubernetes_namespace.external_dns.metadata[0].name
   repository = "https://charts.bitnami.com/bitnami"
   chart      = "external-dns"
-  version    = "3.4.0"
+  version    = "3.4.4"
 
   # For additional configuration options @see https://github.com/bitnami/charts/blob/master/bitnami/external-dns/values.yaml#L258
   # And special thanks to https://itsmetommy.com/2019/06/14/kubernetes-automated-dns-with-externaldns-on-gke/ for clarity

--- a/modules/external-dns/gcp/providers.tf
+++ b/modules/external-dns/gcp/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/flagger/providers.tf
+++ b/modules/flagger/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/fluentbit/providers.tf
+++ b/modules/fluentbit/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/git/gitea/providers.tf
+++ b/modules/git/gitea/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/git/gitea/templates/cert.yml
+++ b/modules/git/gitea/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: gitea-cert

--- a/modules/kibana/providers.tf
+++ b/modules/kibana/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/kibana/templates/cert.yml
+++ b/modules/kibana/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: kibana-cert

--- a/modules/kubeapps/providers.tf
+++ b/modules/kubeapps/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/loki-stack/providers.tf
+++ b/modules/loki-stack/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/loki-stack/templates/cert.yml
+++ b/modules/loki-stack/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: grafana-cert

--- a/modules/metricbeat/providers.tf
+++ b/modules/metricbeat/providers.tf
@@ -2,7 +2,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/minio/providers.tf
+++ b/modules/minio/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/nginx-ingress/providers.tf
+++ b/modules/nginx-ingress/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 terraform {

--- a/modules/registry/harbor/main.tf
+++ b/modules/registry/harbor/main.tf
@@ -44,9 +44,9 @@ resource "helm_release" "harbor" {
   namespace  = kubernetes_namespace.harbor.metadata[0].name
   repository = "https://helm.goharbor.io"
   chart      = "harbor"
-  version    = "1.4.2"
+  version    = "1.5.0"
 
   values = [data.template_file.harbor_config.rendered]
 
-  timeout    = 400
+  timeout    = 600
 }

--- a/modules/registry/harbor/providers.tf
+++ b/modules/registry/harbor/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/registry/harbor/templates/cert.yml
+++ b/modules/registry/harbor/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: harbor-cert

--- a/modules/registry/harbor/templates/contour/values.yml
+++ b/modules/registry/harbor/templates/contour/values.yml
@@ -2,8 +2,10 @@ externalURL: https://${harbor_domain}
 harborAdminPassword: ${admin_password}
 expose:
   tls:
-    secretName: harbor-tls-secret
-    notarySecretName: harbor-tls-secret
+    certSource: secret
+    secret:
+      secretName: harbor-tls-secret
+      notarySecretName: harbor-tls-secret
   ingress:
     hosts:
       core: ${harbor_domain}

--- a/modules/registry/harbor/templates/nginx/values.yml
+++ b/modules/registry/harbor/templates/nginx/values.yml
@@ -2,8 +2,10 @@ externalURL: https://${harbor_domain}
 harborAdminPassword: ${admin_password}
 expose:
   tls:
-    secretName: harbor-tls-secret
-    notarySecretName: harbor-tls-secret
+    certSource: secret
+    secret:
+      secretName: harbor-tls-secret
+      notarySecretName: harbor-tls-secret
   ingress:
     hosts:
       core: ${harbor_domain}

--- a/modules/registry/jcr/providers.tf
+++ b/modules/registry/jcr/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/registry/jcr/templates/cert.yml
+++ b/modules/registry/jcr/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: jcr-cert

--- a/modules/stratos/providers.tf
+++ b/modules/stratos/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/stratos/templates/cert.yml
+++ b/modules/stratos/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: stratos-cert

--- a/modules/tas4k8s/templates/cert.yml
+++ b/modules/tas4k8s/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: tas4k8s-cert
@@ -6,6 +6,7 @@ metadata:
 spec:
   dnsNames:
   - '*.${system_domain}'
+  - '*.${app_domain}'
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-prod

--- a/modules/tsmgr/providers.tf
+++ b/modules/tsmgr/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {

--- a/modules/tsmgr/templates/cert.yml
+++ b/modules/tsmgr/templates/cert.yml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: tsmgr-cert

--- a/modules/wavefront/providers.tf
+++ b/modules/wavefront/providers.tf
@@ -6,7 +6,7 @@ provider "helm" {
   kubernetes {
     config_path = var.kubeconfig_path
   }
-  version = "~> 1.2.0"
+  version = "~> 1.3.1"
 }
 
 provider "k14s" {


### PR DESCRIPTION
* Upgrade cert-manager Helm chart to 1.0.2
* All Certificates and ClusterIssuer employ apiVersion: cert-mamager.io/v1
* Upgrade Terraform Kubernetes provider to 1.3.1
* Upgrade Terraform Azure provider to 2.30.0
* Upgrade Harbor helm chart to 1.5.0
* Upgrade Terraform AWS provider to 3.9.0
* Upgrade Terraform ACME provider to 1.5.0
* Upgrade Octant to 0.16.0 in Linux BOM setup script